### PR TITLE
Bump GitHub Action versions to node24 runtime

### DIFF
--- a/.github/workflows/post-apod.yml
+++ b/.github/workflows/post-apod.yml
@@ -48,10 +48,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           # Node 22 is the current LTS (supported through April 2027).
           # Node 20 still works but emits a deprecation warning on every run.
@@ -67,7 +67,7 @@ jobs:
       # materially improving odds of recovery.
       - name: Post to Instagram
         id: post
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         env:
           META_ACCESS_TOKEN: ${{ secrets.META_ACCESS_TOKEN }}
           IG_BUSINESS_ACCOUNT_ID: ${{ secrets.IG_BUSINESS_ACCOUNT_ID }}


### PR DESCRIPTION
Clears the Node 20 deprecation warning by moving each action to a release that pins node24 in its action.yml.

- actions/checkout v4 -> v5
- actions/setup-node v4 -> v5
- nick-fields/retry v3 -> v4 (inputs unchanged)