### PR TITLE
Add Haiku-based 5-slot hashtag generation

### DIFF
--- a/.github/workflows/post-apod.yml
+++ b/.github/workflows/post-apod.yml
@@ -65,6 +65,11 @@ jobs:
           # Node 20 still works but emits a deprecation warning on every run.
           node-version: "22"
 
+      # Install deps from the committed lockfile. Required now that the
+      # script imports @anthropic-ai/sdk for hashtag generation.
+      - name: Install dependencies
+        run: npm ci
+
       # Layer 2: step-level retry. If the script crashes entirely (in-script
       # Layer 1 retries exhausted, runner blip, etc.), wait 60 seconds and
       # run it again. The script's idempotency check prevents a double-post
@@ -80,6 +85,7 @@ jobs:
           META_ACCESS_TOKEN: ${{ secrets.META_ACCESS_TOKEN }}
           IG_BUSINESS_ACCOUNT_ID: ${{ secrets.IG_BUSINESS_ACCOUNT_ID }}
           NASA_API_KEY: ${{ secrets.NASA_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # Schedule triggers don't pass inputs → inputs.dry_run is empty → empty
           # string in env → script treats as not-true → real post. Manual triggers
           # respect the checkbox, which defaults to true (dry run).

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ SETUP_NOTES.md
 # macOS
 .DS_Store
 
+# Dependencies (restored from package-lock.json via `npm ci`)
+node_modules/
+
 # Editor
 .vscode/
 .idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,74 @@
     "": {
       "name": "nasa",
       "version": "1.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.114.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.114.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.114.0.tgz",
+      "integrity": "sha512-zRFGTVMFEm77gt70Q0B+CDRKa9AcguydCcp6bD/dXWv8UkfsVFqCbaqU8+4B/pob3+Vy434LgtrBmwSvxfKr3g==",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "homepage": "https://miklo88.github.io/nasa-iotd/"
+  "homepage": "https://miklo88.github.io/nasa-iotd/",
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.114.0"
+  }
 }

--- a/poster/post-apod.mjs
+++ b/poster/post-apod.mjs
@@ -34,6 +34,7 @@
 
 import { mkdir, appendFile, readFile } from "node:fs/promises";
 import { dirname } from "node:path";
+import Anthropic from "@anthropic-ai/sdk";
 
 const GRAPH_API_VERSION = "v21.0";
 const NASA_APOD_URL = "https://api.nasa.gov/planetary/apod";
@@ -49,6 +50,7 @@ const {
   META_ACCESS_TOKEN,
   IG_BUSINESS_ACCOUNT_ID,
   NASA_API_KEY = "DEMO_KEY",
+  ANTHROPIC_API_KEY,
 } = process.env;
 
 const DRY_RUN = process.env.DRY_RUN === "true";
@@ -140,19 +142,240 @@ async function fetchAPOD() {
   return res.json();
 }
 
-function buildCaption({ title, explanation, date, copyright }) {
-  const hashtags = [
-    "#nasa",
-    "#apod",
-    "#astronomy",
-    "#space",
-    "#astrophotography",
-    "#cosmos",
-    "#universe",
-    "#nightsky",
-    "#science",
-    "#nasaapod",
-  ].join(" ");
+// ── Hashtag generation ──────────────────────────────────────────────────
+//
+// Instagram suppresses posts from Explore/recommendations when they carry
+// more than 5 hashtags, so we cap at 5 and spend each slot on a distinct
+// *classification* rather than piling on synonyms. Slots:
+//
+//   1. anchor        — always "#apod" (our brand/discovery anchor)
+//   2. object_class  — what kind of object (#nebula, #galaxy, #aurora…)
+//   3. named_subject — the specific named thing (#orionnebula, #jupiter…)
+//   4. community     — the audience community (#astrophotography…)
+//   5. source        — instrument/mission when relevant (#jwst, #hubble…)
+//
+// A Haiku call picks the slots from the APOD title + explanation. Every
+// suggestion is validated in code against approved lists (object_class,
+// community, source) or, for the free-form named_subject, against a
+// hallucination guard: the model must quote a verbatim substring of the
+// APOD text as evidence. Anything that fails validation is dropped, never
+// posted. If the whole call fails (no key, API error, bad JSON), we fall
+// back to a safe static set so a tagging problem never blocks a post.
+
+const HASHTAG_MODEL = "claude-haiku-4-5";
+const HASHTAG_ANCHOR = "apod";
+const HASHTAG_FALLBACK = ["apod", "astrophotography", "astronomy"];
+
+// Approved object-class tags. The model must pick from this list (it maps
+// the APOD subject to the closest class); anything off-list is dropped.
+const OBJECT_CLASS_TAGS = new Set([
+  "nebula",
+  "galaxy",
+  "starcluster",
+  "supernova",
+  "aurora",
+  "comet",
+  "meteor",
+  "eclipse",
+  "moon",
+  "sun",
+  "solareclipse",
+  "lunareclipse",
+  "milkyway",
+  "planet",
+  "star",
+  "blackhole",
+  "galaxycluster",
+  "nightsky",
+  "deepsky",
+  "constellation",
+  "sunset",
+  "planetarynebula",
+  "spiralgalaxy",
+  "cometnucleus",
+  "asteroid",
+]);
+
+// Approved audience-community tags.
+const COMMUNITY_TAGS = new Set([
+  "astrophotography",
+  "deepskyastrophotography",
+  "astronomy",
+  "spacephotography",
+]);
+
+// Approved source/instrument tags.
+const SOURCE_TAGS = new Set([
+  "jwst",
+  "hubbletelescope",
+  "chandra",
+  "esa",
+  "timelapse",
+]);
+
+const HASHTAG_TOKEN_RE = /^[a-z0-9]{3,30}$/;
+
+// Normalize a model-suggested tag to a bare token: strip leading '#',
+// lowercase, remove any non-alphanumerics. Returns "" if nothing usable.
+function normalizeTag(raw) {
+  if (typeof raw !== "string") return "";
+  return raw
+    .trim()
+    .replace(/^#/, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+}
+
+const HASHTAG_SCHEMA = {
+  type: "object",
+  properties: {
+    object_class: {
+      type: "string",
+      description:
+        "The single closest object-class tag for the APOD subject, chosen " +
+        "from the approved list. Empty string if none fits.",
+    },
+    named_subject: {
+      type: "string",
+      description:
+        "A hashtag for the specific named subject (e.g. 'orionnebula' for " +
+        "the Orion Nebula, 'jupiter' for Jupiter). Lowercase, no spaces or " +
+        "punctuation. Empty string if the APOD has no specific named subject.",
+    },
+    named_subject_evidence: {
+      type: "string",
+      description:
+        "A short verbatim quote copied EXACTLY from the APOD title or " +
+        "explanation that proves the named_subject appears in the text. " +
+        "Must be an exact substring. Empty string if named_subject is empty.",
+    },
+    community: {
+      type: "string",
+      description:
+        "The best audience-community tag from the approved list. Empty " +
+        "string if none fits.",
+    },
+    source: {
+      type: "string",
+      description:
+        "The instrument/mission/source tag from the approved list if the " +
+        "APOD text clearly indicates one, else empty string.",
+    },
+  },
+  required: [
+    "object_class",
+    "named_subject",
+    "named_subject_evidence",
+    "community",
+    "source",
+  ],
+  additionalProperties: false,
+};
+
+// Ask Haiku to classify the APOD into hashtag slots, validate every
+// suggestion in code, and return an ordered, deduped, ≤5 array of bare
+// tag tokens (no '#'). Never throws — returns the static fallback on any
+// failure so a tagging problem can't block a post.
+async function generateHashtags({ title, explanation }) {
+  if (!ANTHROPIC_API_KEY) {
+    console.warn(
+      "  ⚠️  ANTHROPIC_API_KEY not set — using static fallback hashtags."
+    );
+    return [...HASHTAG_FALLBACK];
+  }
+
+  const text = `${title}\n\n${explanation}`;
+  const haystack = text.toLowerCase();
+
+  const system =
+    "You classify NASA Astronomy Picture of the Day entries into Instagram " +
+    "hashtag slots. Choose object_class, community, and source ONLY from the " +
+    "approved lists below — if nothing fits a slot, return an empty string " +
+    "for it. For named_subject, produce a hashtag for the specific named " +
+    "astronomical object in the APOD, and copy a verbatim substring of the " +
+    "provided text into named_subject_evidence to prove it appears. Never " +
+    "invent a subject that is not in the text.\n\n" +
+    `Approved object_class: ${[...OBJECT_CLASS_TAGS].join(", ")}\n` +
+    `Approved community: ${[...COMMUNITY_TAGS].join(", ")}\n` +
+    `Approved source: ${[...SOURCE_TAGS].join(", ")}`;
+
+  let slots;
+  try {
+    const client = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
+    const response = await client.messages.create({
+      model: HASHTAG_MODEL,
+      max_tokens: 512,
+      system,
+      messages: [
+        {
+          role: "user",
+          content:
+            `APOD title and explanation:\n\n${text}\n\n` +
+            "Return the hashtag slots for this entry.",
+        },
+      ],
+      output_config: {
+        format: { type: "json_schema", schema: HASHTAG_SCHEMA },
+      },
+    });
+    const raw = response.content.find((b) => b.type === "text")?.text ?? "";
+    slots = JSON.parse(raw);
+  } catch (err) {
+    console.warn(
+      `  ⚠️  Hashtag generation failed (${err.message || err}) — using fallback.`
+    );
+    return [...HASHTAG_FALLBACK];
+  }
+
+  const tags = [HASHTAG_ANCHOR];
+
+  const objectClass = normalizeTag(slots.object_class);
+  if (OBJECT_CLASS_TAGS.has(objectClass)) tags.push(objectClass);
+
+  // named_subject is free-form, so guard against hallucination: the model's
+  // cited evidence must be a real substring of the APOD text.
+  const named = normalizeTag(slots.named_subject);
+  const evidence =
+    typeof slots.named_subject_evidence === "string"
+      ? slots.named_subject_evidence.trim().toLowerCase()
+      : "";
+  if (
+    named &&
+    HASHTAG_TOKEN_RE.test(named) &&
+    evidence.length >= 3 &&
+    haystack.includes(evidence)
+  ) {
+    tags.push(named);
+  } else if (named) {
+    console.warn(
+      `  ⚠️  Dropping named_subject "#${named}" — evidence not found in APOD text.`
+    );
+  }
+
+  const community = normalizeTag(slots.community);
+  if (COMMUNITY_TAGS.has(community)) tags.push(community);
+
+  const source = normalizeTag(slots.source);
+  if (SOURCE_TAGS.has(source)) tags.push(source);
+
+  // Dedupe preserving order, then cap at Instagram's 5-tag sweet spot.
+  const deduped = [...new Set(tags)].slice(0, 5);
+
+  // Guarantee at least the anchor + a couple of safe community tags so we
+  // never post a bare single tag if the model returned mostly empties.
+  if (deduped.length < 3) {
+    for (const t of HASHTAG_FALLBACK) {
+      if (!deduped.includes(t) && deduped.length < 5) deduped.push(t);
+    }
+  }
+
+  return deduped;
+}
+
+function buildCaption({ title, explanation, date, copyright }, hashtagTokens) {
+  const hashtags = (hashtagTokens?.length ? hashtagTokens : HASHTAG_FALLBACK)
+    .map((t) => `#${t}`)
+    .join(" ");
 
   const credit = copyright
     ? `📷 Image credit: ${copyright.trim()} / NASA APOD`
@@ -351,7 +574,12 @@ async function run(record) {
   const mediaUrl = apod.url;
   console.log(`  Media URL:  ${mediaUrl}`);
 
-  const caption = buildCaption(apod);
+  console.log("→ Generating hashtags…");
+  const hashtags = await generateHashtags(apod);
+  console.log(`  Hashtags: ${hashtags.map((t) => `#${t}`).join(" ")}`);
+  record.hashtags = hashtags;
+
+  const caption = buildCaption(apod, hashtags);
   console.log(`→ Caption built (${caption.length} chars)`);
   record.caption_length = caption.length;
 


### PR DESCRIPTION
Replace the flat 10-tag static list with an LLM-classified, 5-slot hashtag system (anchor / object-class / named-subject / community / source) to stay under Instagram's 5-tag recommendation cap and maximize per-slot reach.

Claude Haiku classifies each APOD into approved-list slots; every suggestion is validated in code, with a substring-evidence guard against hallucinated named subjects. Falls back to a safe static tag set on any failure or when ANTHROPIC_API_KEY is absent, so a tagging problem never blocks a post.

Adds @anthropic-ai/sdk dependency, an `npm ci` workflow step, and the ANTHROPIC_API_KEY secret wiring. node_modules/ is now gitignored.