### PR TITLE
Move posting to ~11 AM CT and add same-photo dedup guard

### DIFF
--- a/.github/workflows/post-apod.yml
+++ b/.github/workflows/post-apod.yml
@@ -2,19 +2,26 @@ name: Post APOD to Instagram
 
 # Schedules (all UTC). Times chosen to compensate for GitHub Actions'
 # scheduled-workflow queue delay, which empirically runs ~60–90 min for
-# this repo. Goal is for the *actual* post to land near 9 PM CT.
+# this repo. Goal is for the *actual* post to land near 11 AM CT so it
+# catches people over their lunch break.
 #
-#   01:13 — primary: 8:13 PM CDT (Mar–Nov) / 7:13 PM CST (Nov–Mar) scheduled
-#           → typical actual post around 9:15–9:45 PM CT
-#   03:13 — recovery #1, +2h — catches primary if unusually delayed
-#   05:13 — recovery #2, +4h — final safety net
+#   15:13 — primary: 10:13 AM CDT (Mar–Nov) / 9:13 AM CST (Nov–Mar) scheduled
+#           → typical actual post around 11:15–11:45 AM CT
+#   17:13 — recovery #1, +2h — catches primary if unusually delayed
+#   19:13 — recovery #2, +4h — final safety net
+#
+# All three fires happen mid-day UTC, comfortably after APOD's ~05:00 UTC
+# daily rollover, so every fire sees the same (current-day) photo. That,
+# plus the two idempotency guards below, is what stops the double posts.
 #
 # The :13 minute (instead of :00) dodges the top-of-hour queue congestion
 # that hits GitHub Actions every hour on the hour.
 #
-# All three fires run the same job. The script's idempotency check (reads
-# logs/YYYY-MM.jsonl for a status:"ok" entry from today UTC) makes the
-# recovery fires no-op if the primary already succeeded.
+# All three fires run the same job. Two idempotency guards in the script
+# prevent double-posting: (1) a per-UTC-day check that short-circuits before
+# the APOD fetch, and (2) an authoritative per-APOD-date check that refuses
+# to publish the same photo twice. Once a day's APOD posts OK, every later
+# fire that day no-ops.
 #
 # Also exposes a manual "Run workflow" button for test posts. Manual runs
 # default to DRY_RUN=true; uncheck the box for a real publish.
@@ -23,9 +30,9 @@ name: Post APOD to Instagram
 # Manual (workflow_dispatch) triggers work from any branch.
 on:
   schedule:
-    - cron: "13 1 * * *"  # primary  (01:13 UTC = 8:13 PM CDT / 7:13 PM CST)
-    - cron: "13 3 * * *"  # recovery +2h
-    - cron: "13 5 * * *"  # recovery +4h
+    - cron: "13 15 * * *"  # primary  (15:13 UTC = 10:13 AM CDT / 9:13 AM CST)
+    - cron: "13 17 * * *"  # recovery +2h
+    - cron: "13 19 * * *"  # recovery +4h
   workflow_dispatch:
     inputs:
       dry_run:

--- a/poster/post-apod.mjs
+++ b/poster/post-apod.mjs
@@ -485,14 +485,11 @@ async function writeLog(record) {
   console.log(`📝 Logged to ${path}`);
 }
 
-// Idempotency guard — read the current month's log, return the first OK
-// entry whose timestamp matches today (UTC). Used to short-circuit
-// retries (Layer 2 + 3) if the post already succeeded on an earlier run.
-//
-// Why date-based and not apod-date-based? The cron fires at 02:00 UTC.
-// APOD's "date" field follows US Eastern, so an entry's apod_date may
-// not match today's UTC date. But we only want one post per calendar
-// day — and that calendar day is the day the script runs.
+// Idempotency guard #1 (fast path) — read the current month's log, return
+// the first OK entry whose run timestamp matches today (UTC). Runs BEFORE
+// the APOD fetch so recovery crons short-circuit cheaply without hitting
+// NASA again. With the mid-day schedule (all three fires land on the same
+// UTC calendar day), this reliably catches the "already posted today" case.
 async function findTodaysSuccessfulPost() {
   const todayUTC = new Date().toISOString().slice(0, 10);
   const month = todayUTC.slice(0, 7);
@@ -513,6 +510,39 @@ async function findTodaysSuccessfulPost() {
       continue; // tolerate malformed lines rather than crash
     }
     if (entry.status === "ok" && entry.ts?.startsWith(todayUTC)) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+// Idempotency guard #2 (authoritative) — has THIS SPECIFIC APOD already
+// been posted successfully? Keyed on the APOD's own date (the identity of
+// the photo), not the run's calendar day. This is the real "same photo,
+// never twice" check: it holds even if two fires straddle a UTC midnight,
+// if a run is manually retried on another day, or if NASA hasn't rolled the
+// APOD over yet (in which case we'd re-fetch yesterday's photo — and skip).
+// Runs AFTER the fetch, once we know which APOD we're actually looking at.
+// The log is bucketed by apod_date's month, so we read exactly that file.
+async function findSuccessfulPostForApodDate(apodDate) {
+  if (!apodDate) return null;
+  const month = apodDate.slice(0, 7);
+  const path = `logs/${month}.jsonl`;
+  let content;
+  try {
+    content = await readFile(path, "utf8");
+  } catch (err) {
+    if (err.code === "ENOENT") return null;
+    throw err;
+  }
+  for (const line of content.split("\n").filter(Boolean)) {
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (entry.status === "ok" && entry.apod_date === apodDate) {
       return entry;
     }
   }
@@ -548,6 +578,24 @@ async function run(record) {
   record.apod_title = apod.title;
   record.apod_media_type = apod.media_type;
   record.apod_url = apod.url;
+
+  // Idempotency guard #2 — same photo, never twice. If this exact APOD
+  // (by its date) was already posted OK, stop here and wait for tomorrow's
+  // photo. This is what actually kills the double-posts: an early-hours fire
+  // and a later scheduled fire can both wake up on the same APOD, but only
+  // the first one gets to publish it.
+  if (!DRY_RUN) {
+    const dup = await findSuccessfulPostForApodDate(apod.date);
+    if (dup) {
+      console.log(
+        `✅ APOD ${apod.date} already posted (media_id=${dup.media_id}, at ${dup.ts}).`
+      );
+      console.log("   Skipping — will wait for tomorrow's APOD.");
+      record.status = "already_posted";
+      record.existing_media_id = dup.media_id;
+      return;
+    }
+  }
 
   // Decide the publish path.
   //   image                                → post to feed as image


### PR DESCRIPTION
Shift the cron schedule from evening (01/03/05:13 UTC) to mid-day (15/17/19:13 UTC) so the actual post lands near 11 AM CT and catches the lunch-break audience. All three fires now happen on the same UTC calendar day, after APOD's ~05:00 UTC rollover, so every fire sees the same photo.

Add a second, authoritative idempotency guard keyed on the APOD's own date: once a given day's photo has posted OK, no later fire will publish it again. This kills the double-posts where an early-hours fire and a later scheduled fire both woke up on the same APOD.